### PR TITLE
Require certifi

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 ### SDK Release Checklist
 
 - [ ] Have you added an integration test for the changes?
-- [ ] Have you built the gem locally and made queries against it successfully?
+- [ ] Have you built the library locally and made queries against it successfully?
 - [ ] Did you update the changelog?
 - [ ] Did you bump the package version?
 - [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: Publish
 on:
+  push:
   release:
     types: [created]
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 
 build:
-	pip install -r requirements.txt && \
+	pip install -r requirements.txt \
 	python setup.py install
 
 lint:
@@ -12,4 +12,4 @@ test:
 	pip install -r requirements.txt && \
 	python -m unittest discover test/
 
-.PHONY: build lint test publish
+.PHONY: build test lint publish

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = [
-    "urllib3 >= 1.25.3",
-    "python-dateutil",
-]
+REQUIRES = ["urllib3 >= 1.25.3", "python-dateutil", "certifi"]
 
 setup(
     name=NAME,


### PR DESCRIPTION
### What

Adding "certifi" as a required package. 

### Why

When using the built package, we got an error saying that "certifi" was not installed. 

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
