### PR TITLE
Remove condition on publish causing it not to run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,6 @@ jobs:
           .
 
       - name: Publish a Python distribution to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__


### PR DESCRIPTION
### What

Removing condition causing the PyPi publish step not to run. 