### PR TITLE
Update version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0.pre] - 2021-01-22
+## [1.0.1.pre] - 2021-01-22
 
 ### Added
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "patch-api"
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 # To install the library, run the following
 #
 # python setup.py install
@@ -37,4 +37,5 @@ setup(
     long_description="""\
     The core API used to integrate with Patch&#39;s service.
     """,
+    long_description_content_type="text/x-rst",
 )


### PR DESCRIPTION
### What

Updating version to 1.0.1 because filenames (i.e. versions) cannot be reused on Pypi. 

### Why

** CHANGEME: Why are these changes needed? **

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the library locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
