### PR TITLE
Fix AttributeError when retrieving Projects with SDGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2021-03-02
+
+### Fixed
+
+- Fixed an `AttributeError` that was thrown when Projects with Sustainable Development Goals were retrieved.
+
 ## [1.5.0] - 2021-03-01
 
 ### Changed

--- a/patch_api/__init__.py
+++ b/patch_api/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 # import ApiClient
 from patch_api.api_client import ApiClient

--- a/patch_api/api_client.py
+++ b/patch_api/api_client.py
@@ -91,7 +91,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = "OpenAPI-Generator/1.5.0/python"
+        self.user_agent = "OpenAPI-Generator/1.5.1/python"
 
     def __del__(self):
         if self._pool:

--- a/patch_api/configuration.py
+++ b/patch_api/configuration.py
@@ -341,7 +341,7 @@ class Configuration(object):
             "OS: {env}\n"
             "Python Version: {pyversion}\n"
             "Version of the API: v1\n"
-            "SDK Package Version: 1.5.0".format(env=sys.platform, pyversion=sys.version)
+            "SDK Package Version: 1.5.1".format(env=sys.platform, pyversion=sys.version)
         )
 
     def get_host_settings(self):

--- a/patch_api/models/__init__.py
+++ b/patch_api/models/__init__.py
@@ -32,3 +32,4 @@ from patch_api.models.project import Project
 from patch_api.models.project_list_response import ProjectListResponse
 from patch_api.models.project_response import ProjectResponse
 from patch_api.models.standard import Standard
+from patch_api.models.sdg import Sdg

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "patch-api"
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
### What

- Requiring the SDG model in `models/__init__.py` to ensure we can retrieve Projects with SDGs without errors. 

### Why

- So that we can retrieve all Projects.

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [x] Have you built the library locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
