### PR TITLE
Update type of cents_usd fields in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2021-07-14
+
+### Changed
+
+- [BREAKING] Changed `order.price_cents_usd` and `order.patch_fee_cents_usd` from string to integer.
+
 ## [1.6.0] - 2021-07-14
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	python setup.py install
 
 lint:
-	pip install -r test-requirements.txt && \
+	pip install black && \
 	black .
 
 test:

--- a/patch_api/__init__.py
+++ b/patch_api/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 # import ApiClient
 from patch_api.api_client import ApiClient

--- a/patch_api/api_client.py
+++ b/patch_api/api_client.py
@@ -91,7 +91,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = "OpenAPI-Generator/1.6.0/python"
+        self.user_agent = "OpenAPI-Generator/1.7.0/python"
 
     def __del__(self):
         if self._pool:

--- a/patch_api/configuration.py
+++ b/patch_api/configuration.py
@@ -341,7 +341,7 @@ class Configuration(object):
             "OS: {env}\n"
             "Python Version: {pyversion}\n"
             "Version of the API: v1\n"
-            "SDK Package Version: 1.6.0".format(env=sys.platform, pyversion=sys.version)
+            "SDK Package Version: 1.7.0".format(env=sys.platform, pyversion=sys.version)
         )
 
     def get_host_settings(self):

--- a/patch_api/models/order.py
+++ b/patch_api/models/order.py
@@ -39,8 +39,8 @@ class Order(object):
         "production": "bool",
         "state": "str",
         "allocation_state": "str",
-        "price_cents_usd": "str",
-        "patch_fee_cents_usd": "str",
+        "price_cents_usd": "int",
+        "patch_fee_cents_usd": "int",
         "allocations": "list[Allocation]",
         "registry_url": "str",
         "metadata": "object",
@@ -295,7 +295,7 @@ class Order(object):
         The total price in cents USD of the carbon offsets purchased through this order.  # noqa: E501
 
         :return: The price_cents_usd of this Order.  # noqa: E501
-        :rtype: str
+        :rtype: int
         """
         return self._price_cents_usd
 
@@ -306,7 +306,7 @@ class Order(object):
         The total price in cents USD of the carbon offsets purchased through this order.  # noqa: E501
 
         :param price_cents_usd: The price_cents_usd of this Order.  # noqa: E501
-        :type: str
+        :type: int
         """
 
         self._price_cents_usd = price_cents_usd
@@ -318,7 +318,7 @@ class Order(object):
         The Patch Fee in cents USD for this order.  # noqa: E501
 
         :return: The patch_fee_cents_usd of this Order.  # noqa: E501
-        :rtype: str
+        :rtype: int
         """
         return self._patch_fee_cents_usd
 
@@ -329,7 +329,7 @@ class Order(object):
         The Patch Fee in cents USD for this order.  # noqa: E501
 
         :param patch_fee_cents_usd: The patch_fee_cents_usd of this Order.  # noqa: E501
-        :type: str
+        :type: int
         """
 
         self._patch_fee_cents_usd = patch_fee_cents_usd

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "patch-api"
-VERSION = "1.6.0"
+VERSION = "1.7.0"
 # To install the library, run the following
 #
 # python setup.py install

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-black>=21.6b0
 pytest~=4.6.7 # needed for python 2.7+3.4
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4

--- a/test/test_orders_api.py
+++ b/test/test_orders_api.py
@@ -38,7 +38,6 @@ class TestOrdersApi(unittest.TestCase):
 
         self.assertTrue(order)
 
-        print(order)
         self.assertEqual(order.mass_g, 100)
 
         """Create an order on price

--- a/test/test_orders_api.py
+++ b/test/test_orders_api.py
@@ -30,7 +30,7 @@ class TestOrdersApi(unittest.TestCase):
         self.api = None
 
     def test_interactions_with_an_order(self):
-        """Test case for create_order, retrieve_order"""
+        """Test case for create_order"""
 
         """Create an order
         """
@@ -38,11 +38,18 @@ class TestOrdersApi(unittest.TestCase):
 
         self.assertTrue(order)
 
+        print(order)
+        self.assertEqual(order.mass_g, 100)
+
         """Create an order on price
         """
         order = self.api.create_order(total_price_cents_usd=100)
 
         self.assertTrue(order)
+        self.assertEqual(order.price_cents_usd + order.patch_fee_cents_usd, 100)
+
+    def test_retrieve_order(self):
+        """Test case for retrieve_order"""
 
         """Retrieve an order
         """
@@ -50,6 +57,7 @@ class TestOrdersApi(unittest.TestCase):
         retrieved_order = self.api.retrieve_order(id=order.data.id)
 
         self.assertTrue(retrieved_order)
+        self.assertEqual(retrieved_order.mass_g, 100)
 
     def test_retrieve_orders(self):
         """Test case for retrieve_orders

--- a/test/test_orders_api.py
+++ b/test/test_orders_api.py
@@ -38,14 +38,16 @@ class TestOrdersApi(unittest.TestCase):
 
         self.assertTrue(order)
 
-        self.assertEqual(order.mass_g, 100)
+        self.assertEqual(order.data.mass_g, 100)
 
         """Create an order on price
         """
         order = self.api.create_order(total_price_cents_usd=100)
 
         self.assertTrue(order)
-        self.assertEqual(order.price_cents_usd + order.patch_fee_cents_usd, 100)
+        self.assertEqual(
+            order.data.price_cents_usd + order.data.patch_fee_cents_usd, 100
+        )
 
     def test_retrieve_order(self):
         """Test case for retrieve_order"""
@@ -56,7 +58,7 @@ class TestOrdersApi(unittest.TestCase):
         retrieved_order = self.api.retrieve_order(id=order.data.id)
 
         self.assertTrue(retrieved_order)
-        self.assertEqual(retrieved_order.mass_g, 100)
+        self.assertEqual(retrieved_order.data.mass_g, 100)
 
     def test_retrieve_orders(self):
         """Test case for retrieve_orders


### PR DESCRIPTION
### What

- Update `order.price_cents_usd` and `order.patch_fee_cents_usd` from string to integer

### Why

- An integer value is more natural and directly usable by a consumer of the API

### Notes

- Because of the way type coercion works in the python SDK, this version will only pass the tests and work once the API update is released.

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the library locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [x] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
