### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL = /bin/bash
 
-build:
+build: install lint
+
+install:
 	pip install -r requirements.txt && \
 	python setup.py install
 


### PR DESCRIPTION
### What

- A small change in the `Makefile` that allows us to use the same command `make build` for all SDKs when generating new versions.

### Why

- Standardize

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the library locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
