### PR TITLE
Add created_at on orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2021-09-08
+
+### Added
+
+- Adds a `created_at` attribute in all order responses
+
 ## [1.11.0] - 2021-09-07
 
 ### Added

--- a/patch_api/__init__.py
+++ b/patch_api/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 # import ApiClient
 from patch_api.api_client import ApiClient

--- a/patch_api/api_client.py
+++ b/patch_api/api_client.py
@@ -91,7 +91,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = "patch-python/1.11.0"
+        self.user_agent = "patch-python/1.12.0"
 
     def __del__(self):
         if self._pool:

--- a/patch_api/configuration.py
+++ b/patch_api/configuration.py
@@ -341,7 +341,7 @@ class Configuration(object):
             "OS: {env}\n"
             "Python Version: {pyversion}\n"
             "Version of the API: v1\n"
-            "SDK Package Version: 1.11.0".format(
+            "SDK Package Version: 1.12.0".format(
                 env=sys.platform, pyversion=sys.version
             )
         )

--- a/patch_api/models/create_bitcoin_estimate_request.py
+++ b/patch_api/models/create_bitcoin_estimate_request.py
@@ -34,7 +34,7 @@ class CreateBitcoinEstimateRequest(object):
                             and the value is json key in definition.
     """
     openapi_types = {
-        "timestamp": "str",
+        "timestamp": "datetime",
         "transaction_value_btc_sats": "int",
         "project_id": "str",
         "create_order": "bool",
@@ -77,7 +77,7 @@ class CreateBitcoinEstimateRequest(object):
 
 
         :return: The timestamp of this CreateBitcoinEstimateRequest.  # noqa: E501
-        :rtype: str
+        :rtype: datetime
         """
         return self._timestamp
 
@@ -87,7 +87,7 @@ class CreateBitcoinEstimateRequest(object):
 
 
         :param timestamp: The timestamp of this CreateBitcoinEstimateRequest.  # noqa: E501
-        :type: str
+        :type: datetime
         """
 
         self._timestamp = timestamp

--- a/patch_api/models/order.py
+++ b/patch_api/models/order.py
@@ -35,6 +35,7 @@ class Order(object):
     """
     openapi_types = {
         "id": "str",
+        "created_at": "datetime",
         "mass_g": "int",
         "production": "bool",
         "state": "str",
@@ -48,6 +49,7 @@ class Order(object):
 
     attribute_map = {
         "id": "id",
+        "created_at": "created_at",
         "mass_g": "mass_g",
         "production": "production",
         "state": "state",
@@ -62,6 +64,7 @@ class Order(object):
     def __init__(
         self,
         id=None,
+        created_at=None,
         mass_g=None,
         production=None,
         state=None,
@@ -79,6 +82,7 @@ class Order(object):
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None
+        self._created_at = None
         self._mass_g = None
         self._production = None
         self._state = None
@@ -91,6 +95,8 @@ class Order(object):
         self.discriminator = None
 
         self.id = id
+        if created_at is not None:
+            self.created_at = created_at
         self.mass_g = mass_g
         self.production = production
         self.state = state
@@ -128,6 +134,29 @@ class Order(object):
             raise ValueError("Invalid value for `id`, must not be `None`")  # noqa: E501
 
         self._id = id
+
+    @property
+    def created_at(self):
+        """Gets the created_at of this Order.  # noqa: E501
+
+        The timestamp at which the order was created  # noqa: E501
+
+        :return: The created_at of this Order.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._created_at
+
+    @created_at.setter
+    def created_at(self, created_at):
+        """Sets the created_at of this Order.
+
+        The timestamp at which the order was created  # noqa: E501
+
+        :param created_at: The created_at of this Order.  # noqa: E501
+        :type: datetime
+        """
+
+        self._created_at = created_at
 
     @property
     def mass_g(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "patch-api"
-VERSION = "1.11.0"
+VERSION = "1.12.0"
 # To install the library, run the following
 #
 # python setup.py install

--- a/test/test_orders_api.py
+++ b/test/test_orders_api.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 import unittest
 import os
+import datetime
 
 from patch_api.api_client import ApiClient
 
@@ -37,6 +38,8 @@ class TestOrdersApi(unittest.TestCase):
         order = self.api.create_order(mass_g=100)
 
         self.assertTrue(order)
+
+        self.assertIsInstance(order.data.created_at, datetime.datetime)
 
         self.assertEqual(order.data.mass_g, 100)
 


### PR DESCRIPTION
### What

- Surface the `created_at` field on all order responses

### Why

- For ease of use when retrieving orders

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the library locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
