### PR TITLE
Update to make the order allocations array optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2022-01-11
+
+### Changed
+
+- Set the order allocatations array as optional.
+
 ## [1.16.0] - 2021-12-07
 
 ### Removed

--- a/patch_api/__init__.py
+++ b/patch_api/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.16.0"
+__version__ = "1.17.0"
 
 # import ApiClient
 from patch_api.api_client import ApiClient

--- a/patch_api/api_client.py
+++ b/patch_api/api_client.py
@@ -91,7 +91,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = "patch-python/1.16.0"
+        self.user_agent = "patch-python/1.17.0"
 
     def __del__(self):
         if self._pool:

--- a/patch_api/configuration.py
+++ b/patch_api/configuration.py
@@ -341,7 +341,7 @@ class Configuration(object):
             "OS: {env}\n"
             "Python Version: {pyversion}\n"
             "Version of the API: v1\n"
-            "SDK Package Version: 1.16.0".format(
+            "SDK Package Version: 1.17.0".format(
                 env=sys.platform, pyversion=sys.version
             )
         )

--- a/patch_api/models/order.py
+++ b/patch_api/models/order.py
@@ -103,7 +103,8 @@ class Order(object):
         self.allocation_state = allocation_state
         self.price_cents_usd = price_cents_usd
         self.patch_fee_cents_usd = patch_fee_cents_usd
-        self.allocations = allocations
+        if allocations is not None:
+            self.allocations = allocations
         if registry_url is not None:
             self.registry_url = registry_url
         self.metadata = metadata
@@ -304,7 +305,7 @@ class Order(object):
             raise ValueError(
                 "Invalid value for `allocation_state`, must not be `None`"
             )  # noqa: E501
-        allowed_values = ["pending", "partially_allocated", "allocated"]  # noqa: E501
+        allowed_values = ["pending", "allocated"]  # noqa: E501
         if (
             self.local_vars_configuration.client_side_validation
             and allocation_state not in allowed_values
@@ -367,7 +368,7 @@ class Order(object):
     def allocations(self):
         """Gets the allocations of this Order.  # noqa: E501
 
-        An array containing the inventory allocations for this order.  # noqa: E501
+        DEPRECATED. An array containing the inventory allocations for this order.  # noqa: E501
 
         :return: The allocations of this Order.  # noqa: E501
         :rtype: list[Allocation]
@@ -378,17 +379,11 @@ class Order(object):
     def allocations(self, allocations):
         """Sets the allocations of this Order.
 
-        An array containing the inventory allocations for this order.  # noqa: E501
+        DEPRECATED. An array containing the inventory allocations for this order.  # noqa: E501
 
         :param allocations: The allocations of this Order.  # noqa: E501
         :type: list[Allocation]
         """
-        if (
-            self.local_vars_configuration.client_side_validation and allocations is None
-        ):  # noqa: E501
-            raise ValueError(
-                "Invalid value for `allocations`, must not be `None`"
-            )  # noqa: E501
 
         self._allocations = allocations
 

--- a/patch_api/models/project.py
+++ b/patch_api/models/project.py
@@ -273,7 +273,7 @@ class Project(object):
     def type(self):
         """Gets the type of this Project.  # noqa: E501
 
-        Deprecated. Favor the technology_type field instead.  # noqa: E501
+        DEPRECATED. Favor the technology_type field instead.  # noqa: E501
 
         :return: The type of this Project.  # noqa: E501
         :rtype: str
@@ -284,7 +284,7 @@ class Project(object):
     def type(self, type):
         """Sets the type of this Project.
 
-        Deprecated. Favor the technology_type field instead.  # noqa: E501
+        DEPRECATED. Favor the technology_type field instead.  # noqa: E501
 
         :param type: The type of this Project.  # noqa: E501
         :type: str

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "patch-api"
-VERSION = "1.16.0"
+VERSION = "1.17.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
### What

* Changing the order allocations array to be optional

### Why

* Allocations will not always be available for an order 

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the library locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
