### PR TITLE
1.20.0 - create order by vintage year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2022-04-18
+
+### Added
+
+- Adds optional `vintage_year` field to `order` creation
+
 ## [1.19.0] - 2022-04-11
 ### Added
 

--- a/patch_api/__init__.py
+++ b/patch_api/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.19.0"
+__version__ = "1.20.0"
 
 # import ApiClient
 from patch_api.api_client import ApiClient

--- a/patch_api/api/estimates_api.py
+++ b/patch_api/api/estimates_api.py
@@ -58,6 +58,7 @@ class EstimatesApi(object):
         "star_rating",
         "number_of_nights",
         "number_of_rooms",
+        "vintage_year",
     ]
 
     def __init__(self, api_client=None):
@@ -156,6 +157,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -325,6 +327,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -494,6 +497,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -663,6 +667,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -832,6 +837,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -1001,6 +1007,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -1170,6 +1177,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -1333,6 +1341,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -1486,6 +1495,7 @@ class EstimatesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:

--- a/patch_api/api/orders_api.py
+++ b/patch_api/api/orders_api.py
@@ -58,6 +58,7 @@ class OrdersApi(object):
         "star_rating",
         "number_of_nights",
         "number_of_rooms",
+        "vintage_year",
     ]
 
     def __init__(self, api_client=None):
@@ -150,6 +151,7 @@ class OrdersApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -305,6 +307,7 @@ class OrdersApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -468,6 +471,7 @@ class OrdersApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -621,6 +625,7 @@ class OrdersApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -785,6 +790,7 @@ class OrdersApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:

--- a/patch_api/api/projects_api.py
+++ b/patch_api/api/projects_api.py
@@ -58,6 +58,7 @@ class ProjectsApi(object):
         "star_rating",
         "number_of_nights",
         "number_of_rooms",
+        "vintage_year",
     ]
 
     def __init__(self, api_client=None):
@@ -150,6 +151,7 @@ class ProjectsApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:
@@ -309,6 +311,7 @@ class ProjectsApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:

--- a/patch_api/api/technology_types_api.py
+++ b/patch_api/api/technology_types_api.py
@@ -58,6 +58,7 @@ class TechnologyTypesApi(object):
         "star_rating",
         "number_of_nights",
         "number_of_rooms",
+        "vintage_year",
     ]
 
     def __init__(self, api_client=None):
@@ -148,6 +149,7 @@ class TechnologyTypesApi(object):
         all_params.append("star_rating")
         all_params.append("number_of_nights")
         all_params.append("number_of_rooms")
+        all_params.append("vintage_year")
 
         for key, val in six.iteritems(local_var_params["kwargs"]):
             if key not in all_params:

--- a/patch_api/api_client.py
+++ b/patch_api/api_client.py
@@ -91,7 +91,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = "patch-python/1.19.0"
+        self.user_agent = "patch-python/1.20.0"
 
     def __del__(self):
         if self._pool:

--- a/patch_api/configuration.py
+++ b/patch_api/configuration.py
@@ -341,7 +341,7 @@ class Configuration(object):
             "OS: {env}\n"
             "Python Version: {pyversion}\n"
             "Version of the API: v1\n"
-            "SDK Package Version: 1.19.0".format(
+            "SDK Package Version: 1.20.0".format(
                 env=sys.platform, pyversion=sys.version
             )
         )

--- a/patch_api/models/create_order_request.py
+++ b/patch_api/models/create_order_request.py
@@ -39,6 +39,7 @@ class CreateOrderRequest(object):
         "project_id": "str",
         "metadata": "object",
         "state": "str",
+        "vintage_year": "int",
     }
 
     attribute_map = {
@@ -47,6 +48,7 @@ class CreateOrderRequest(object):
         "project_id": "project_id",
         "metadata": "metadata",
         "state": "state",
+        "vintage_year": "vintage_year",
     }
 
     def __init__(
@@ -56,6 +58,7 @@ class CreateOrderRequest(object):
         project_id=None,
         metadata=None,
         state=None,
+        vintage_year=None,
         local_vars_configuration=None,
     ):  # noqa: E501
         """CreateOrderRequest - a model defined in OpenAPI"""  # noqa: E501
@@ -68,18 +71,15 @@ class CreateOrderRequest(object):
         self._project_id = None
         self._metadata = None
         self._state = None
+        self._vintage_year = None
         self.discriminator = None
 
-        if mass_g is not None:
-            self.mass_g = mass_g
-        if total_price_cents_usd is not None:
-            self.total_price_cents_usd = total_price_cents_usd
-        if project_id is not None:
-            self.project_id = project_id
-        if metadata is not None:
-            self.metadata = metadata
-        if state is not None:
-            self.state = state
+        self.mass_g = mass_g
+        self.total_price_cents_usd = total_price_cents_usd
+        self.project_id = project_id
+        self.metadata = metadata
+        self.state = state
+        self.vintage_year = vintage_year
 
     @property
     def mass_g(self):
@@ -207,7 +207,7 @@ class CreateOrderRequest(object):
         :param state: The state of this CreateOrderRequest.  # noqa: E501
         :type: str
         """
-        allowed_values = ["draft", "placed"]  # noqa: E501
+        allowed_values = [None, "draft", "placed"]  # noqa: E501
         if (
             self.local_vars_configuration.client_side_validation
             and state not in allowed_values
@@ -219,6 +219,43 @@ class CreateOrderRequest(object):
             )
 
         self._state = state
+
+    @property
+    def vintage_year(self):
+        """Gets the vintage_year of this CreateOrderRequest.  # noqa: E501
+
+
+        :return: The vintage_year of this CreateOrderRequest.  # noqa: E501
+        :rtype: int
+        """
+        return self._vintage_year
+
+    @vintage_year.setter
+    def vintage_year(self, vintage_year):
+        """Sets the vintage_year of this CreateOrderRequest.
+
+
+        :param vintage_year: The vintage_year of this CreateOrderRequest.  # noqa: E501
+        :type: int
+        """
+        if (
+            self.local_vars_configuration.client_side_validation
+            and vintage_year is not None
+            and vintage_year > 2100
+        ):  # noqa: E501
+            raise ValueError(
+                "Invalid value for `vintage_year`, must be a value less than or equal to `2100`"
+            )  # noqa: E501
+        if (
+            self.local_vars_configuration.client_side_validation
+            and vintage_year is not None
+            and vintage_year < 1900
+        ):  # noqa: E501
+            raise ValueError(
+                "Invalid value for `vintage_year`, must be a value greater than or equal to `1900`"
+            )  # noqa: E501
+
+        self._vintage_year = vintage_year
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "patch-api"
-VERSION = "1.19.0"
+VERSION = "1.20.0"
 # To install the library, run the following
 #
 # python setup.py install

--- a/test/test_orders_api.py
+++ b/test/test_orders_api.py
@@ -112,6 +112,12 @@ class TestOrdersApi(unittest.TestCase):
         cancelled_order = self.api.cancel_order(id=order.data.id)
         self.assertEqual(cancelled_order.data.state, "cancelled")
 
+    def test_create_order_with_vintage_year(self):
+        """Test case for vintage_year on create order"""
+        order = self.api.create_order(mass_g=100, vintage_year=2022)
+
+        self.assertTrue(order)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What

- enabling vintage year to create projects: https://github.com/patch-technology/patch/pull/1864

### Why

- so that users can order a specific vintage year

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [ ] Have you built the library locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
