### PR TITLE
Test with latest stable Python (3.12)

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -9,13 +9,13 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        python: ['3.6']
+        python: ['3.12']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
### What

Bump the Python version in the CI health check from 3.6 to 3.12 (latest stable minor version).

### Why

Python 3.6 isn't supported anymore on GitHub Actions `ubuntu-latest` workers.